### PR TITLE
Add agentic AI simulation single-page demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,559 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Agentic AI Playground</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-gradient: radial-gradient(circle at top left, #7f5af0, transparent 55%),
+        radial-gradient(circle at bottom right, #2cb1bc, transparent 45%),
+        #0f172a;
+      --card-bg: rgba(15, 23, 42, 0.75);
+      --accent: #7f5af0;
+      --accent-soft: rgba(127, 90, 240, 0.25);
+      --text-primary: #f8fafc;
+      --text-secondary: #cbd5f5;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      min-height: 100vh;
+      background: var(--bg-gradient);
+      color: var(--text-primary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 20px;
+    }
+
+    .shell {
+      width: min(1100px, 100%);
+      background: rgba(15, 23, 42, 0.65);
+      border-radius: 28px;
+      padding: 32px;
+      box-shadow: 0 30px 80px rgba(15, 23, 42, 0.5);
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+    }
+
+    header h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      letter-spacing: -0.5px;
+    }
+
+    header p {
+      color: var(--text-secondary);
+      max-width: 500px;
+      line-height: 1.45;
+      margin-top: 8px;
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 1.2fr 0.8fr;
+      gap: 28px;
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 22px;
+      padding: 20px;
+      position: relative;
+      border: 1px solid rgba(148, 163, 184, 0.1);
+    }
+
+    .card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      padding: 1px;
+      background: linear-gradient(135deg, rgba(127, 90, 240, 0.35), rgba(44, 177, 188, 0.2));
+      -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+      -webkit-mask-composite: xor;
+      mask-composite: exclude;
+      pointer-events: none;
+    }
+
+    .workspace {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      gap: 16px;
+    }
+
+    .tools {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .tool {
+      background: rgba(15, 23, 42, 0.75);
+      border-radius: 18px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      border: 1px solid rgba(148, 163, 184, 0.08);
+      transition: transform 0.4s ease, box-shadow 0.4s ease;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .tool.active {
+      transform: translateY(-6px);
+      box-shadow: 0 15px 35px rgba(127, 90, 240, 0.35);
+      border-color: rgba(127, 90, 240, 0.6);
+    }
+
+    .tool-icon {
+      font-size: 1.4rem;
+      margin-bottom: 10px;
+    }
+
+    .tool span {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .timeline {
+      background: rgba(12, 17, 33, 0.85);
+      border-radius: 18px;
+      padding: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.08);
+      max-height: 220px;
+      overflow: auto;
+      scroll-behavior: smooth;
+    }
+
+    .timeline h3 {
+      font-size: 0.95rem;
+      margin-bottom: 12px;
+      color: var(--text-secondary);
+    }
+
+    .step {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 12px;
+      border-radius: 14px;
+      background: rgba(148, 163, 184, 0.08);
+      margin-bottom: 10px;
+      border-left: 3px solid transparent;
+      transition: border-color 0.3s ease, background 0.3s ease;
+    }
+
+    .step.active {
+      border-color: var(--accent);
+      background: rgba(127, 90, 240, 0.15);
+      box-shadow: 0 12px 24px rgba(127, 90, 240, 0.25);
+    }
+
+    .step strong {
+      font-size: 0.9rem;
+    }
+
+    .step p {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      margin-top: 4px;
+      line-height: 1.4;
+    }
+
+    .chat {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      gap: 16px;
+    }
+
+    .chat-window {
+      flex: 1;
+      background: rgba(12, 17, 33, 0.85);
+      border-radius: 18px;
+      padding: 20px;
+      border: 1px solid rgba(148, 163, 184, 0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      overflow: hidden;
+    }
+
+    .messages {
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding-right: 6px;
+    }
+
+    .bubble {
+      max-width: 85%;
+      padding: 14px 16px;
+      border-radius: 16px;
+      line-height: 1.5;
+      font-size: 0.92rem;
+      position: relative;
+      animation: fadeUp 0.5s ease;
+    }
+
+    .bubble.user {
+      align-self: flex-end;
+      background: linear-gradient(135deg, #7f5af0, #6244d3);
+    }
+
+    .bubble.agent {
+      align-self: flex-start;
+      background: rgba(148, 163, 184, 0.12);
+      border: 1px solid rgba(148, 163, 184, 0.15);
+    }
+
+    @keyframes fadeUp {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .prompt-palette {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 12px;
+    }
+
+    .prompt-btn {
+      background: rgba(127, 90, 240, 0.12);
+      border: 1px solid rgba(127, 90, 240, 0.4);
+      border-radius: 14px;
+      padding: 12px;
+      color: var(--text-primary);
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+      text-align: left;
+      line-height: 1.3;
+    }
+
+    .prompt-btn:hover:not([disabled]) {
+      transform: translateY(-4px);
+      box-shadow: 0 10px 25px rgba(127, 90, 240, 0.28);
+      background: rgba(127, 90, 240, 0.25);
+    }
+
+    .prompt-btn[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .status-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: #22c55e;
+      margin-right: 6px;
+      box-shadow: 0 0 12px rgba(34, 197, 94, 0.8);
+    }
+
+    .status {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .reset {
+      background: transparent;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      border-radius: 12px;
+      color: var(--text-secondary);
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .reset:hover {
+      background: rgba(148, 163, 184, 0.15);
+      color: var(--text-primary);
+    }
+
+    @media (max-width: 980px) {
+      body {
+        padding: 24px 16px;
+      }
+      .layout {
+        grid-template-columns: 1fr;
+      }
+      .shell {
+        padding: 24px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header>
+      <div>
+        <h1>Agentic AI Playground</h1>
+        <p>Explore how an agentic AI collaborates with you. Tap on a prompt to watch the agent plan, choose tools, and execute tasks inside its workspace, turning your intent into action.</p>
+      </div>
+      <div class="status">
+        <span class="status-dot"></span>
+        <span>Agent Online</span>
+      </div>
+    </header>
+
+    <div class="layout">
+      <section class="card workspace">
+        <div>
+          <h2 style="font-size: 1.05rem; margin-bottom: 12px; color: var(--text-secondary);">Agent Workspace</h2>
+          <div class="tools" id="tools">
+            <div class="tool" data-tool="calendar">
+              <div class="tool-icon">📅</div>
+              <strong>Calendar</strong>
+              <span>Check availability</span>
+            </div>
+            <div class="tool" data-tool="email">
+              <div class="tool-icon">📧</div>
+              <strong>Email</strong>
+              <span>Draft outreach</span>
+            </div>
+            <div class="tool" data-tool="browser">
+              <div class="tool-icon">🌐</div>
+              <strong>Web Search</strong>
+              <span>Research info</span>
+            </div>
+            <div class="tool" data-tool="docs">
+              <div class="tool-icon">📝</div>
+              <strong>Docs</strong>
+              <span>Summaries & plans</span>
+            </div>
+            <div class="tool" data-tool="slides">
+              <div class="tool-icon">📊</div>
+              <strong>Slides</strong>
+              <span>Visual reporting</span>
+            </div>
+            <div class="tool" data-tool="chat">
+              <div class="tool-icon">💬</div>
+              <strong>Team Chat</strong>
+              <span>Updates & sync</span>
+            </div>
+            <div class="tool" data-tool="code">
+              <div class="tool-icon">💻</div>
+              <strong>Automation</strong>
+              <span>Run scripts</span>
+            </div>
+            <div class="tool" data-tool="dashboard">
+              <div class="tool-icon">📈</div>
+              <strong>Dashboards</strong>
+              <span>Monitor metrics</span>
+            </div>
+          </div>
+        </div>
+        <div class="timeline" id="timeline">
+          <h3>Agent Action Timeline</h3>
+          <p style="font-size: 0.85rem; color: var(--text-secondary);">Select a prompt to see the agent reason and act.</p>
+        </div>
+      </section>
+
+      <section class="card chat">
+        <div class="chat-window">
+          <div class="messages" id="messages"></div>
+          <div class="status-bar">
+            <div class="status" id="statusText">
+              <span class="status-dot" style="background:#38bdf8; box-shadow:0 0 12px rgba(56,189,248,0.9);"></span>
+              Waiting for your prompt
+            </div>
+            <button class="reset" id="resetBtn" hidden>Reset</button>
+          </div>
+        </div>
+        <div>
+          <h3 style="font-size: 0.95rem; margin-bottom: 10px; color: var(--text-secondary);">Try a scenario</h3>
+          <div class="prompt-palette">
+            <button class="prompt-btn" data-scenario="offsite">Plan a team offsite</button>
+            <button class="prompt-btn" data-scenario="report">Summarize weekly metrics</button>
+            <button class="prompt-btn" data-scenario="inbox">Triage my inbox</button>
+            <button class="prompt-btn" data-scenario="code">Fix the failing test</button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const scenarios = {
+      offsite: {
+        user: "Plan a team offsite in late April and make sure the weather looks good.",
+        steps: [
+          { tool: "calendar", title: "Check calendars", detail: "Scan team availability the last week of April." },
+          { tool: "browser", title: "Research weather", detail: "Compare weather forecasts for coastal vs. mountain spots." },
+          { tool: "docs", title: "Draft itinerary", detail: "Outline travel, lodging, and activities based on availability." },
+          { tool: "chat", title: "Share plan", detail: "Send the itinerary to the leadership channel for approval." },
+        ],
+        response: "Here's a draft offsite plan with a sunny coastal venue, coordinated travel, and budget notes ready for approval.",
+      },
+      report: {
+        user: "Summarize this week's product metrics and call out anything unusual.",
+        steps: [
+          { tool: "dashboard", title: "Review dashboards", detail: "Pull conversion, retention, and NPS trends." },
+          { tool: "docs", title: "Analyze anomalies", detail: "Detect the dip in onboarding completion and link to release notes." },
+          { tool: "slides", title: "Visualize findings", detail: "Create a three-slide overview with charts and key insights." },
+          { tool: "email", title: "Send recap", detail: "Email the summary to product & GTM leads with next steps." },
+        ],
+        response: "Summary ready: conversions +4%, onboarding completion -6% (root cause noted), and suggested follow-ups dispatched.",
+      },
+      inbox: {
+        user: "Triage my inbox and highlight anything urgent.",
+        steps: [
+          { tool: "email", title: "Scan new mail", detail: "Sort by priority and detect deadlines or blockers." },
+          { tool: "docs", title: "Draft digests", detail: "Summarize action items with due dates and context." },
+          { tool: "chat", title: "Ping stakeholders", detail: "Nudge owners for responses where items are blocked." },
+          { tool: "calendar", title: "Block time", detail: "Reserve focus slots to tackle high-priority items." },
+        ],
+        response: "Inbox triaged: urgent items flagged, responses drafted, and focus time booked for you tomorrow morning.",
+      },
+      code: {
+        user: "Investigate and fix the failing checkout test.",
+        steps: [
+          { tool: "code", title: "Run test suite", detail: "Reproduce the failure and capture stack trace." },
+          { tool: "docs", title: "Trace change history", detail: "Review recent commits touching checkout logic." },
+          { tool: "browser", title: "Search docs", detail: "Look up API changes for payment provider version 2.1." },
+          { tool: "chat", title: "Notify team", detail: "Post fix summary with PR link to engineering channel." },
+        ],
+        response: "Checkout test repaired by updating the payment client. Added regression test and notified the team.",
+      },
+    };
+
+    const messagesEl = document.getElementById('messages');
+    const timelineEl = document.getElementById('timeline');
+    const promptButtons = document.querySelectorAll('.prompt-btn');
+    const tools = document.querySelectorAll('.tool');
+    const statusText = document.getElementById('statusText');
+    const resetBtn = document.getElementById('resetBtn');
+
+    let running = false;
+
+    function createBubble(text, type) {
+      const bubble = document.createElement('div');
+      bubble.className = `bubble ${type}`;
+      bubble.textContent = text;
+      messagesEl.appendChild(bubble);
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+
+    function clearTimeline() {
+      const extraSteps = timelineEl.querySelectorAll('.step');
+      extraSteps.forEach(step => step.remove());
+    }
+
+    function setToolsActive(toolName) {
+      tools.forEach(tool => {
+        tool.classList.toggle('active', tool.dataset.tool === toolName);
+      });
+    }
+
+    function resetTools() {
+      tools.forEach(tool => tool.classList.remove('active'));
+    }
+
+    function updateStatus(text, color = '#38bdf8') {
+      statusText.innerHTML = `<span class="status-dot" style="background:${color}; box-shadow:0 0 12px ${hexToRGBA(color, 0.9)};"></span>${text}`;
+    }
+
+    function hexToRGBA(hex, alpha) {
+      const trimmed = hex.replace('#', '');
+      const bigint = parseInt(trimmed, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    function playScenario(key) {
+      running = true;
+      const scenario = scenarios[key];
+      clearTimeline();
+      createBubble(scenario.user, 'user');
+      updateStatus('Agent thinking…', '#f97316');
+
+      const stepsFragment = document.createDocumentFragment();
+
+      scenario.steps.forEach((step, index) => {
+        const stepEl = document.createElement('div');
+        stepEl.className = 'step';
+        stepEl.innerHTML = `<div><strong>${index + 1}. ${step.title}</strong><p>${step.detail}</p></div>`;
+        stepsFragment.appendChild(stepEl);
+      });
+
+      timelineEl.appendChild(stepsFragment);
+      timelineEl.scrollTop = 0;
+
+      const stepElements = timelineEl.querySelectorAll('.step');
+
+      scenario.steps.forEach((step, index) => {
+        setTimeout(() => {
+          setToolsActive(step.tool);
+          stepElements.forEach(el => el.classList.remove('active'));
+          stepElements[index].classList.add('active');
+          updateStatus(`Agent executing: ${step.title}`, '#7f5af0');
+        }, index * 2200 + 600);
+      });
+
+      setTimeout(() => {
+        resetTools();
+        stepElements.forEach(el => el.classList.remove('active'));
+        createBubble(scenario.response, 'agent');
+        updateStatus('Agent ready for another task', '#22c55e');
+        running = false;
+        resetBtn.hidden = false;
+        promptButtons.forEach(btn => (btn.disabled = false));
+      }, scenario.steps.length * 2200 + 1100);
+    }
+
+    promptButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        if (running) return;
+        promptButtons.forEach(btn => (btn.disabled = true));
+        resetBtn.hidden = true;
+        playScenario(button.dataset.scenario);
+      });
+    });
+
+    resetBtn.addEventListener('click', () => {
+      running = false;
+      messagesEl.innerHTML = '';
+      clearTimeline();
+      resetTools();
+      updateStatus('Waiting for your prompt', '#38bdf8');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a single-page "Agentic AI Playground" demonstrating how an agent reasons through tasks
- add interactive chat, tool highlights, and action timeline to visualize planning and execution
- style the experience with modern gradients, glassmorphism, and responsive layout for engaging onboarding

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4ef71e84c832bb9632404bc534bc0